### PR TITLE
Adjust app bar menu icon size and color

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -463,7 +463,7 @@
   }
   
   .mobile-appbar .drawer-toggle {
-    @apply w-8 h-8 flex items-center justify-center text-gray-600;
+    @apply w-14 h-14 flex items-center justify-center text-primary text-2xl font-black;
   }
   
   /* 移动端抽屉遮罩 */


### PR DESCRIPTION
Increase the size, line thickness, and color of the mobile appbar menu button to improve visual consistency with the home button.

---
<a href="https://cursor.com/background-agent?bcId=bc-61f8a23d-2aed-4fc2-a6df-6da4e7d28110">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61f8a23d-2aed-4fc2-a6df-6da4e7d28110">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

